### PR TITLE
Update opf.py for spillage variables

### DIFF
--- a/pypsa/opf.py
+++ b/pypsa/opf.py
@@ -162,7 +162,7 @@ def define_storage_variables_constraints(network,snapshots):
     def su_p_spill_bounds(model,su_name,snapshot):
         return spill_bounds[su_name,snapshot]
 
-    network.model.storage_p_spill = Var(spill_index, domain=NonNegativeReals, bounds=su_p_spill_bounds)
+    network.model.storage_p_spill = Var(list(spill_index), domain=NonNegativeReals, bounds=su_p_spill_bounds)
 
 
 


### PR DESCRIPTION
Pyomo does not recognize the spill_index dictionary tuples, but does recognize it as a list instead.
Not passing it as a list results in the following error (example of storage unit 31, snapshot 0):

ERROR: Constructing component 'storage_p_spill_index' from data=None failed:
  File "C:\Anaconda3\lib\site-packages\pypsa\opf.py", line 768, in network_lopf
	ValueError: The value=('31', 0) is a tuple for set=storage_p_spill_index, which has dimen=1