### PR TITLE
Correct branch convention

### DIFF
--- a/doc/links.csv
+++ b/doc/links.csv
@@ -12,6 +12,6 @@ p_min_pu,float,per unit of p_nom,0.,"Minimal dispatch (can also be negative) per
 p_max_pu,float,per unit of p_nom,1.,"Maximal dispatch (can also be negative) per unit of p_nom for the link in OPF.",Input (optional)
 capital_cost,float,currency/MW,0.,"Capital cost of extending p_nom by 1 MW.",Input (optional)
 marginal_cost,float,currency/MWh,0.,"Marginal cost of transfering 1 MWh (before efficiency losses) from bus0 to bus1.",Input (optional)
-p0,series of floats,MW,0.,Active power at bus0 (positive if bus is withdrawing power).,Output
-p1,series of floats,MW,0.,Active power at bus1 (positive if bus is withdrawing power).,Output
+p0,series of floats,MW,0.,Active power at bus0 (positive if bus is injecting power).,Output
+p1,series of floats,MW,0.,Active power at bus1 (positive if bus is injecting power).,Output
 p_nom_opt,float,MVA,0.,Optimised capacity for active power.,Output


### PR DESCRIPTION
Branch p and q descriptions conflict with sign convention on documentation and code (branches p and q are positive if bus is injecting power).
