### PR TITLE
Correct branch convention

### DIFF
--- a/doc/lines.csv
+++ b/doc/lines.csv
@@ -13,10 +13,10 @@ s_nom_max,float,MVA,inf,"If s_nom is extendable in OPF, set its maximum value (e
 capital_cost,float,currency/MVA,0.,"Capital cost of extending s_nom by 1 MVA.",Input (optional)
 length,float,km,0.,"Length of line, useful for calculating the capital cost.",Input (optional)
 terrain_factor,float,per unit,1.,"Terrain factor for increasing capital cost.",Input (optional)
-p0,series of floats,MW,0.,Active power at bus0 (positive if bus is withdrawing power).,Output
-q0,series of floats,MVar,0.,Reactive power at bus0 (positive if bus is withdrawing power).,Output
-p1,series of floats,MW,0.,Active power at bus1 (positive if bus is withdrawing power).,Output
-q1,series of floats,MVar,0.,Reactive power at bus1 (positive if bus is withdrawing power).,Output
+p0,series of floats,MW,0.,Active power at bus0 (positive if bus is injecting power).,Output
+q0,series of floats,MVar,0.,Reactive power at bus0 (positive if bus is injecting power).,Output
+p1,series of floats,MW,0.,Active power at bus1 (positive if bus is injecting power).,Output
+q1,series of floats,MVar,0.,Reactive power at bus1 (positive if bus is injecting power).,Output
 x_pu,float,per unit,0.,Per unit series reactance calculated by PyPSA from x and bus.v_nom.,Output
 r_pu,float,per unit,0.,Per unit series resistance calculated by PyPSA from r and bus.v_nom,Output
 g_pu,float,per unit,0.,Per unit shunt conductivity calculated by PyPSA from g and bus.v_nom,Output


### PR DESCRIPTION
Branch p and q descriptions conflict with sign convention on documentation and code (branches p and q are positive if bus is injecting power).
