### PR TITLE
Update co2_price exception

### DIFF
--- a/pypsa/opf.py
+++ b/pypsa/opf.py
@@ -971,7 +971,7 @@ def extract_optimisation_results(network, snapshots, formulation="angles"):
     if network.co2_limit is not None:
         try:
             network.co2_price = - network.model.dual[network.model.co2_constraint]
-        except AttributeError, KeyError:
+        except (AttributeError, KeyError):
             logger.warning("Could not read out co2_price, although a co2_limit was set")
 
 


### PR DESCRIPTION
Multiple exception types should be a tuple following https://docs.python.org/3/tutorial/errors.html#handling-exceptions
Otherwise a syntax error is raised in Python 3.5.2, though I wonder whether this is compatible with Python 2.